### PR TITLE
Track merge history for leads and contacts

### DIFF
--- a/src/classes/ContactMergeResultTriggerTest.cls
+++ b/src/classes/ContactMergeResultTriggerTest.cls
@@ -1,0 +1,130 @@
+@isTest
+private class ContactMergeResultTriggerTest {
+
+    @isTest
+    private static void mergeContacts() {
+
+        // Given
+        Contact bugs = [
+            SELECT Id
+            FROM Contact
+            WHERE LastName = 'Bunny (TEST)'
+        ];
+
+        Contact daffy = [
+            SELECT Id
+            FROM Contact
+            WHERE LastName = 'Duck (TEST)'
+        ];
+
+        // When
+        Test.startTest();
+
+        merge bugs daffy;
+
+        // Then
+        Test.stopTest();
+
+        MergeResult__c result = [
+            SELECT Id,
+                EffectiveMasterRecordId__c,
+                MasterRecordId__c, MergedRecordId__c
+            FROM MergeResult__c
+            WHERE MergedRecordId__c = :daffy.Id
+        ];
+
+        System.assertEquals(bugs.Id, result.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+
+        System.assertEquals(bugs.Id, result.MasterRecordId__c,
+                Schema.MergeResult__c.fields.MasterRecordId__c.getDescribe().label);
+    }
+
+    @isTest
+    private static void mergeContactsTwice() {
+
+        // Given
+        Contact bugs = [
+            SELECT Id
+            FROM Contact
+            WHERE LastName = 'Bunny (TEST)'
+        ];
+
+        Contact daffy = [
+            SELECT Id
+            FROM Contact
+            WHERE LastName = 'Duck (TEST)'
+        ];
+
+        Contact elmer = [
+            SELECT Id
+            FROM Contact
+            WHERE LastName = 'Fudd (TEST)'
+        ];
+
+        // When
+        Test.startTest();
+
+        merge daffy elmer;
+        merge bugs daffy;
+
+        // Then
+        Test.stopTest();
+
+        MergeResult__c firstMergeResult = [
+            SELECT Id,
+                EffectiveMasterRecordId__c
+            FROM MergeResult__c
+            WHERE MasterRecordId__c = :daffy.Id
+            AND MergedRecordId__c = :elmer.Id
+        ];
+
+        System.assertEquals(bugs.Id, firstMergeResult.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+
+        MergeResult__c secondMergeResult = [
+            SELECT Id,
+                EffectiveMasterRecordId__c
+            FROM MergeResult__c
+            WHERE MasterRecordId__c = :bugs.Id
+            AND MergedRecordId__c = :daffy.Id
+        ];
+
+        System.assertEquals(bugs.Id, secondMergeResult.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+    }
+
+    @testSetup
+    private static void setup() {
+
+        // Create accounts
+        Account acme = new Account(
+                Name = 'Acme Corporation (TEST)');
+
+        Account dc = new Account(
+                Name = 'DC Universe (TEST)');
+
+        Account marvel = new Account(
+                Name = 'Marvel Universe (TEST)');
+
+        insert new List<Account> { acme, dc, marvel };
+
+        // Create contacts
+        Contact bugs = new Contact(
+                AccountId = acme.Id,
+                FirstName = 'Bugs',
+                LastName = 'Bunny (TEST)');
+
+        Contact daffy = new Contact(
+                AccountId = acme.Id,
+                FirstName = 'Daffy',
+                LastName = 'Duck (TEST)');
+
+        Contact elmer = new Contact(
+                AccountId = acme.Id,
+                FirstName = 'Elmer',
+                LastName = 'Fudd (TEST)');
+
+        insert new List<Contact> { bugs, daffy, elmer };
+    }
+}

--- a/src/classes/ContactMergeResultTriggerTest.cls-meta.xml
+++ b/src/classes/ContactMergeResultTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ContactMergeResultTriggerTest.cls-meta.xml
+++ b/src/classes/ContactMergeResultTriggerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LeadMergeResultTriggerTest.cls
+++ b/src/classes/LeadMergeResultTriggerTest.cls
@@ -1,5 +1,130 @@
-public with sharing class LeadMergeResultTriggerTest {
-	public LeadMergeResultTriggerTest() {
-		
-	}
+@isTest
+private class LeadMergeResultTriggerTest {
+
+    @isTest
+    private static void mergeLeads() {
+
+        // Given
+        Lead bugs = [
+            SELECT Id
+            FROM Lead
+            WHERE LastName = 'Bunny (TEST)'
+        ];
+
+        Lead daffy = [
+            SELECT Id
+            FROM Lead
+            WHERE LastName = 'Duck (TEST)'
+        ];
+
+        // When
+        Test.startTest();
+
+        merge bugs daffy;
+
+        // Then
+        Test.stopTest();
+
+        MergeResult__c result = [
+            SELECT Id,
+                EffectiveMasterRecordId__c,
+                MasterRecordId__c, MergedRecordId__c
+            FROM MergeResult__c
+            WHERE MergedRecordId__c = :daffy.Id
+        ];
+
+        System.assertEquals(bugs.Id, result.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+
+        System.assertEquals(bugs.Id, result.MasterRecordId__c,
+                Schema.MergeResult__c.fields.MasterRecordId__c.getDescribe().label);
+    }
+
+    @isTest
+    private static void mergeLeadsTwice() {
+
+        // Given
+        Lead bugs = [
+            SELECT Id
+            FROM Lead
+            WHERE LastName = 'Bunny (TEST)'
+        ];
+
+        Lead daffy = [
+            SELECT Id
+            FROM Lead
+            WHERE LastName = 'Duck (TEST)'
+        ];
+
+        Lead elmer = [
+            SELECT Id
+            FROM Lead
+            WHERE LastName = 'Fudd (TEST)'
+        ];
+
+        // When
+        Test.startTest();
+
+        merge daffy elmer;
+        merge bugs daffy;
+
+        // Then
+        Test.stopTest();
+
+        MergeResult__c firstMergeResult = [
+            SELECT Id,
+                EffectiveMasterRecordId__c
+            FROM MergeResult__c
+            WHERE MasterRecordId__c = :daffy.Id
+            AND MergedRecordId__c = :elmer.Id
+        ];
+
+        System.assertEquals(bugs.Id, firstMergeResult.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+
+        MergeResult__c secondMergeResult = [
+            SELECT Id,
+                EffectiveMasterRecordId__c
+            FROM MergeResult__c
+            WHERE MasterRecordId__c = :bugs.Id
+            AND MergedRecordId__c = :daffy.Id
+        ];
+
+        System.assertEquals(bugs.Id, secondMergeResult.EffectiveMasterRecordId__c,
+                Schema.MergeResult__c.fields.EffectiveMasterRecordId__c.getDescribe().label);
+    }
+
+    @testSetup
+    private static void setup() {
+
+        // Create accounts
+        Account acme = new Account(
+                Name = 'Acme Corporation (TEST)');
+
+        Account dc = new Account(
+                Name = 'DC Universe (TEST)');
+
+        Account marvel = new Account(
+                Name = 'Marvel Universe (TEST)');
+
+        insert new List<Account> { acme, dc, marvel };
+
+        // Create leads
+        Lead bugs = new Lead(
+                Company = acme.Name,
+                FirstName = 'Bugs',
+                LastName = 'Bunny (TEST)');
+
+        Lead daffy = new Lead(
+                Company = acme.Name,
+                FirstName = 'Daffy',
+                LastName = 'Duck (TEST)');
+
+        Lead elmer = new Lead(
+                Company = acme.Name,
+                FirstName = 'Elmer',
+                LastName = 'Fudd (TEST)');
+
+        insert new List<Lead> { bugs, daffy, elmer };
+    }
 }

--- a/src/classes/LeadMergeResultTriggerTest.cls
+++ b/src/classes/LeadMergeResultTriggerTest.cls
@@ -1,0 +1,5 @@
+public with sharing class LeadMergeResultTriggerTest {
+	public LeadMergeResultTriggerTest() {
+		
+	}
+}

--- a/src/classes/LeadMergeResultTriggerTest.cls-meta.xml
+++ b/src/classes/LeadMergeResultTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/LeadMergeResultTriggerTest.cls-meta.xml
+++ b/src/classes/LeadMergeResultTriggerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/customMetadata/MergeResultFieldMapping.LeadId.md
+++ b/src/customMetadata/MergeResultFieldMapping.LeadId.md
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead: Lead ID</label>
+    <protected>false</protected>
+    <values>
+        <field>FieldName__c</field>
+        <value xsi:type="xsd:string">Id</value>
+    </values>
+    <values>
+        <field>ResultFieldEnding__c</field>
+        <value xsi:type="xsd:string">Id__c</value>
+    </values>
+    <values>
+        <field>SobjectName__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+</CustomMetadata>

--- a/src/package.xml
+++ b/src/package.xml
@@ -5,11 +5,15 @@
         <members>MergeResultService</members>
         <members>MergeResultServiceTest</members>
         <members>MergeResultUtil</members>
+        <members>ContactMergeResultTriggerTest</members>
+        <members>LeadMergeResultTriggerTest</members>
         <name>ApexClass</name>
     </types>
     <types>
         <members>AccountMergeResultTrigger</members>
         <members>MergeResultTrigger</members>
+        <members>LeadMergeResultTrigger</members>
+        <members>ContactMergeResultTrigger</members>
         <name>ApexTrigger</name>
     </types>
     <types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -23,6 +23,7 @@
     <types>
         <members>MergeResultFieldMapping.AccountId</members>
         <members>MergeResultFieldMapping.ContactId</members>
+        <members>MergeResultFieldMapping.LeadId</members>
         <name>CustomMetadata</name>
     </types>
     <types>

--- a/src/triggers/ContactMergeResultTrigger.trigger
+++ b/src/triggers/ContactMergeResultTrigger.trigger
@@ -1,0 +1,16 @@
+trigger ContactMergeResultTrigger on Contact (after delete) {
+
+    // Initialize the list of merge results to create
+    List<MergeResult__c> results = new List<MergeResult__c>();
+
+    // Get the merge result service for the correct object
+    MergeResultService service =
+            MergeResultService.getInstance(Contact.sobjectType);
+
+    for (Sobject eachRecord : Trigger.old) {
+        results.add(service.getMergeResult(eachRecord));
+    }
+
+    // Create the merge results
+    insert results;
+}

--- a/src/triggers/ContactMergeResultTrigger.trigger-meta.xml
+++ b/src/triggers/ContactMergeResultTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/src/triggers/ContactMergeResultTrigger.trigger-meta.xml
+++ b/src/triggers/ContactMergeResultTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/src/triggers/LeadMergeResultTrigger.trigger
+++ b/src/triggers/LeadMergeResultTrigger.trigger
@@ -1,0 +1,16 @@
+trigger LeadMergeResultTrigger on Lead (after delete) {
+
+    // Initialize the list of merge results to create
+    List<MergeResult__c> results = new List<MergeResult__c>();
+
+    // Get the merge result service for the correct object
+    MergeResultService service =
+            MergeResultService.getInstance(Lead.sobjectType);
+
+    for (Sobject eachRecord : Trigger.old) {
+        results.add(service.getMergeResult(eachRecord));
+    }
+
+    // Create the merge results
+    insert results;
+}

--- a/src/triggers/LeadMergeResultTrigger.trigger-meta.xml
+++ b/src/triggers/LeadMergeResultTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/src/triggers/LeadMergeResultTrigger.trigger-meta.xml
+++ b/src/triggers/LeadMergeResultTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>39.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>


### PR DESCRIPTION
This pr resolves #2 by adding two triggers that provide support for tracking merge history for leads and contacts, out of the box. Now, when the package is deployed, merge results for both _leads_ and _contacts_ will be tracked automatically, in addition to results for accounts.