### PR TITLE
Address SOQL injection vulnerability

### DIFF
--- a/force-app/main/default/classes/MergeResultService.cls
+++ b/force-app/main/default/classes/MergeResultService.cls
@@ -32,8 +32,14 @@ global with sharing class MergeResultService {
     }
 
     global String getMasterRecordQuery(List<String> fieldNames) {
+
+        // Escape the field names to avoid SOQL injection
+        String joinedFieldNames = String.escapeSingleQuotes(
+            String.join(fieldNames, ', ')
+        );
+
         List<String> queryParts = new List<String> {
-            'SELECT ' + String.join(fieldNames, ', '),
+            'SELECT ' + joinedFieldNames,
             'FROM ' + this.objectName,
             'WHERE Id = :recordId'
         };

--- a/force-app/main/default/classes/MergeResultService.cls
+++ b/force-app/main/default/classes/MergeResultService.cls
@@ -6,7 +6,9 @@ global with sharing class MergeResultService {
     private String objectName;
 
     global MergeResultService(String objectName) {
-        this.objectName = objectName;
+
+        // Escape object name parameter to avoid SOQL injection
+        this.objectName = String.escapeSingleQuotes(objectName);
     }
 
     global List<MergeResultFieldMapping__mdt> getFieldMappings() {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,7 +3,8 @@
         {
             "path": "force-app",
             "default": true,
-            "package": "0Ho2E000000KyncSAC"
+            "package": "0Ho2E000000KyncSAC",
+            "ancestorVersion": "1.0.0"
         }
     ],
     "namespace": "Uatu",
@@ -11,6 +12,7 @@
     "sourceApiVersion": "44.0",
     "packageAliases": {
         "DML History@0.1.0-2": "04t2E000003SPV2QAO",
-        "DML History@1.0.0-1": "04t2E000003SPV7QAO"
+        "DML History@1.0.0-1": "04t2E000003SPV7QAO",
+        "DML History@1.0.1-1": "04t2E000003SPfYQAW"
     }
 }


### PR DESCRIPTION
This pr resolves the SOQL injection vulnerabilities identified in #24 by using `String.escapeSingleQuotes(String)` to sanitize potentially unsafe strings.